### PR TITLE
Disable undo on heightmap

### DIFF
--- a/Libraries/Editor/HeightMapTool.cpp
+++ b/Libraries/Editor/HeightMapTool.cpp
@@ -4,7 +4,7 @@
 namespace Plasma
 {
 
-static const bool cAllowUndo = true;
+static const bool cAllowUndo = false;
 
 /// The default name we give any created height maps
 const String cHeightMapName("HeightMap");

--- a/Libraries/Editor/HeightMapTool.hpp
+++ b/Libraries/Editor/HeightMapTool.hpp
@@ -343,7 +343,8 @@ DeclareEnum2(CellIndexType, Local, Absoulte)
     ///     </description>
     ///   </command>
     /// </Commands>
-    class HeightMapTool : public Component
+
+class HeightMapTool : public Component
 {
 public:
   /// Meta Initialization.

--- a/Libraries/Engine/HeightMap.cpp
+++ b/Libraries/Engine/HeightMap.cpp
@@ -232,6 +232,7 @@ void HeightMap::Initialize(CogInitializer& initializer)
 
   // Get a pointer to the transform
   mTransform = GetOwner()->has(Transform);
+  DoNotify("Experimental Feature", "Heightmap feature is experimental... Do not use in production...", "Error");
 }
 
 HeightMapSource* HeightMap::GetSource()


### PR DESCRIPTION
This fixes a few issues related to height map tools.
I also added a warning to the component when created to inform users the feature is experimental.