### PR TITLE
Camera settings in editor viewport and tooltip changes

### DIFF
--- a/Libraries/Editor/EditorCameraController.cpp
+++ b/Libraries/Editor/EditorCameraController.cpp
@@ -59,6 +59,7 @@ void EditorCameraController::Initialize(CogInitializer& initializer)
   {
     SetEnabled(true);
   }
+  ConnectThisTo(initializer.mSpace, Events::ViewportCameraSettings, CameraSettingsChanged);
 }
 
 void EditorCameraController::OnDestroy(uint flags)
@@ -154,6 +155,11 @@ void EditorCameraController::SetEditMode(EditorMode::Enum mode)
     mCamera->SetPerspectiveMode(PerspectiveMode::Perspective);
     SetControlMode(mPrevious3DMode);
   }
+}
+
+void EditorCameraController::CameraSettingsChanged(ViewportCameraEvent* camEvent)
+{
+  mMoveSensitivity = camEvent->mSpeed;
 }
 
 void EditorCameraController::OnAllObjectsCreated(CogInitializer& initializer)

--- a/Libraries/Editor/EditorCameraController.hpp
+++ b/Libraries/Editor/EditorCameraController.hpp
@@ -124,6 +124,8 @@ public:
   EditorMode::Enum GetEditMode();
   void SetEditMode(EditorMode::Enum mode);
 
+  void CameraSettingsChanged(ViewportCameraEvent* camEvent);
+  
   real mMinCameraSize;
   real mMaxCameraSize;
 

--- a/Libraries/Editor/EditorViewportMenu.cpp
+++ b/Libraries/Editor/EditorViewportMenu.cpp
@@ -116,6 +116,7 @@ EditorViewportMenu::EditorViewportMenu(EditorViewport* viewport) : Composite(vie
   mCameraSpeedSlider->SetSizing(SizeAxis::X, SizePolicy::Fixed, Pixels(64));
   mCameraSpeedSlider->SetRange(.1f, 10);
   mCameraSpeedSlider->SetValue(1, false);
+  mCameraSpeedSlider->SetToolTip("Editor camera movement speed");
   ConnectThisTo(mCameraSpeedSlider, Events::SliderChanged, OnCameraSpeedChanged);
   
   ConnectThisTo(this, Events::MouseEnter, OnMouseEnter);

--- a/Libraries/Editor/EditorViewportMenu.cpp
+++ b/Libraries/Editor/EditorViewportMenu.cpp
@@ -83,15 +83,14 @@ EditorViewportMenu::EditorViewportMenu(EditorViewport* viewport) : Composite(vie
   mPerspectiveMode->SetToolTip("Perspective Mode");
   ConnectThisTo(mPerspectiveMode, Events::ButtonPressed, OnPerspectiveModePressed);
 
-  // Camera options
-  mCameraButton = new ViewportMenuButton(this);
-  mCameraButton->SetIcon("CameraOptions");
-  mCameraButton->SetSizing(SizeAxis::X, SizePolicy::Fixed, Pixels(38));
-  mCameraButton->SetToolTip("Camera Options");
-  mCameraButton->mIcon->SetInteractive(false);
-  mCameraButton->mExpandIcon->SetInteractive(false);
-  ConnectThisTo(mCameraButton, Events::ButtonPressed, OnCameraButtonPressed);
 
+  mGridButton = new ToggleIconButton(this);
+  mGridButton->SetEnabledIcon("ViewportGridIconOn");
+  mGridButton->SetDisabledIcon("ViewportGridIconOff");
+  mGridButton->SetSizing(SizeAxis::X, SizePolicy::Fixed, Pixels(19));
+  mGridButton->SetToolTip("Toggle Grids");
+  ConnectThisTo(mGridButton, Events::ButtonPressed, OnGridButtonPressed);
+  
   // Debug options
   mDebugButton = new ViewportMenuButton(this);
   mDebugButton->SetIcon("DebugIcon");
@@ -101,13 +100,24 @@ EditorViewportMenu::EditorViewportMenu(EditorViewport* viewport) : Composite(vie
   mDebugButton->mExpandIcon->SetInteractive(false);
   ConnectThisTo(mDebugButton, Events::ButtonPressed, OnDebugButtonPressed);
   
-  mGridButton = new ToggleIconButton(this);
-  mGridButton->SetEnabledIcon("ViewportGridIconOn");
-  mGridButton->SetDisabledIcon("ViewportGridIconOff");
-  mGridButton->SetSizing(SizeAxis::X, SizePolicy::Fixed, Pixels(19));
-  mGridButton->SetToolTip("Toggle Grids");
-  ConnectThisTo(mGridButton, Events::ButtonPressed, OnGridButtonPressed);
 
+  // Camera options
+  mCameraButton = new ViewportMenuButton(this);
+  mCameraButton->SetIcon("CameraOptions");
+  mCameraButton->SetSizing(SizeAxis::X, SizePolicy::Fixed, Pixels(38));
+  mCameraButton->SetToolTip("Camera Options");
+  mCameraButton->mIcon->SetInteractive(false);
+  mCameraButton->mExpandIcon->SetInteractive(false);
+  ConnectThisTo(mCameraButton, Events::ButtonPressed, OnCameraButtonPressed);
+
+  
+  // Debug options
+  mCameraSpeedSlider = new Slider(this, SliderType::Number);
+  mCameraSpeedSlider->SetSizing(SizeAxis::X, SizePolicy::Fixed, Pixels(64));
+  mCameraSpeedSlider->SetRange(.1f, 10);
+  mCameraSpeedSlider->SetValue(1, false);
+  ConnectThisTo(mCameraSpeedSlider, Events::SliderChanged, OnCameraSpeedChanged);
+  
   ConnectThisTo(this, Events::MouseEnter, OnMouseEnter);
   ConnectThisTo(this, Events::MouseExit, OnMouseExit);
 }
@@ -228,6 +238,13 @@ void EditorViewportMenu::OnCameraButtonPressed(Event* e)
 
   mActivePopup = contextMenu;
   ConnectThisTo(contextMenu, Events::PopUpClosed, OnPopUpClosed);
+}
+
+void EditorViewportMenu::OnCameraSpeedChanged(Event* e)
+{
+  Space* space = PL::gEditor->mActiveSpace;
+  ViewportCameraEvent cameraEvent = ViewportCameraEvent(mCameraSpeedSlider->GetValue());
+  space->GetDispatcher()->Dispatch(Events::ViewportCameraSettings, &cameraEvent);
 }
 
 void EditorViewportMenu::OnDebugButtonPressed(Event* e)

--- a/Libraries/Editor/EditorViewportMenu.hpp
+++ b/Libraries/Editor/EditorViewportMenu.hpp
@@ -50,6 +50,8 @@ public:
   /// Camera stuff
   void OnCameraButtonPressed(Event* e);
   
+  void OnCameraSpeedChanged(Event* e);
+  
   void OnDebugButtonPressed(Event* e);
 
   void OnGridButtonPressed(Event* e);
@@ -74,7 +76,12 @@ public:
   /// Grid toggle.
   ToggleIconButton* mGridButton;
 
+  /// Rendering debug button.
   ViewportMenuButton* mDebugButton;
+
+  /// Editor camera speed slider.
+  Element* mRunningMan;
+  Slider* mCameraSpeedSlider;
   
   Element* mBackground;
 };

--- a/Libraries/Engine/DebugCommands.cpp
+++ b/Libraries/Engine/DebugCommands.cpp
@@ -4,6 +4,7 @@ namespace Plasma
     namespace Events
     {
         DefineEvent(DebugViewMode);
+        DefineEvent(ViewportCameraSettings);
     } // namespace Events
 
     LightningDefineType(DebugViewEvent, builder, type)
@@ -13,6 +14,16 @@ namespace Plasma
         LightningBindDefaultCopyDestructor();
         LightningBindFieldProperty(mMode);
         LightningFullBindConstructor(builder, type, LightningSelf, "mode", GeometryValue::Enum);
+        type->CreatableInScript = true;
+    }
+
+    LightningDefineType(ViewportCameraEvent, builder, type)
+    {
+        PlasmaBindEvent(Events::ViewportCameraSettings, ViewportCameraEvent);
+        PlasmaBindDocumented();
+        LightningBindDefaultCopyDestructor();
+        LightningBindFieldProperty(mSpeed);
+        LightningFullBindConstructor(builder, type, LightningSelf, "speed", float);
         type->CreatableInScript = true;
     }
 } // namespace Plasma

--- a/Libraries/Engine/DebugCommands.hpp
+++ b/Libraries/Engine/DebugCommands.hpp
@@ -7,7 +7,8 @@ namespace Plasma
     {
         DeclareEvent(ScriptInitialize);
         DeclareEvent(DebugViewMode);
-    } // namespace Eventsd
+        DeclareEvent(ViewportCameraSettings);
+    } // namespace Events
 
     class DebugViewEvent : public Event
     {
@@ -18,5 +19,17 @@ namespace Plasma
         ~DebugViewEvent() { }
         GeometryValue::Enum mMode = GeometryValue::Enum::None;
     };
+    
+    class ViewportCameraEvent : public Event
+    {
+    public:
+        LightningDeclareType(ViewportCameraEvent, TypeCopyMode::ReferenceType);
+        ViewportCameraEvent(float speed): mSpeed(speed)  { }
+        ViewportCameraEvent()  { }
+        ~ViewportCameraEvent() { }
+        
+        float mSpeed = 1.0f;
+    };
+    
 
 } // Namespace Plasma

--- a/Libraries/Engine/EngineStandard.cpp
+++ b/Libraries/Engine/EngineStandard.cpp
@@ -206,6 +206,7 @@ LightningDefineStaticLibrary(EngineLibrary)
   LightningInitializeType(LightningCompileEvent);
   LightningInitializeType(SplineEvent);
   LightningInitializeType(DebugViewEvent);
+  LightningInitializeType(ViewportCameraEvent);
   LightningInitializeType(BlockingTaskEvent);
   LightningInitializeType(AsyncProcessEvent);
 

--- a/Libraries/Widget/Button.cpp
+++ b/Libraries/Widget/Button.cpp
@@ -44,9 +44,7 @@ LightningDefineType(ButtonBase, builder, type)
 {
 }
 
-ButtonBase::ButtonBase(Composite* parent, StringParam styleClass) :
-    Composite(parent),
-    mToolTipColor(ToolTipColorScheme::Default)
+ButtonBase::ButtonBase(Composite* parent, StringParam styleClass) : Composite(parent)
 {
   mDefSet = mDefSet->GetDefinitionSet(styleClass);
 
@@ -62,7 +60,6 @@ ButtonBase::ButtonBase(Composite* parent, StringParam styleClass) :
   ConnectThisTo(this, Events::MouseExitHierarchy, OnMouseExit);
   ConnectThisTo(this, Events::LeftMouseDown, OnMouseDown);
   ConnectThisTo(this, Events::LeftMouseUp, OnMouseUp);
-  ConnectThisTo(this, Events::MouseHover, OnHover);
   ConnectThisTo(this, Events::LeftClick, OnMouseClick);
   ConnectThisTo(this, Events::KeyDown, OnKeyDown);
 
@@ -73,18 +70,12 @@ ButtonBase::ButtonBase(Composite* parent, StringParam styleClass) :
   mMouseOver = false;
   mTabFocusStop = true;
   mIgnoreInput = false;
-  mShowToolTip = true;
 
   mBorderColor = ToByteColor(ButtonUi::BorderColor);
   mFocusBorderColor = ToByteColor(ButtonUi::FocusBorderColor);
   mBackgroundColor = ToByteColor(ButtonUi::DefaultColor);
   mBackgroundHoverColor = ToByteColor(ButtonUi::HoverColor);
   mBackgroundClickedColor = ToByteColor(ButtonUi::ClickedColor);
-}
-
-void ButtonBase::SetToolTip(StringParam text)
-{
-  mToolTipText = text;
 }
 
 void ButtonBase::AddCommand(Command* command)
@@ -150,46 +141,6 @@ void ButtonBase::OnMouseUp(MouseEvent* event)
   MarkAsNeedsUpdate();
 }
 
-void ButtonBase::OnHover(MouseEvent* event)
-{
-  if (mShowToolTip)
-  {
-    ToolTip* toolTip = new ToolTip(this);
-
-    bool hasText = false;
-    forRange (Command* command, mCommands.All())
-    {
-      hasText |= (!command->ToolTip.Empty());
-      if (hasText)
-        toolTip->AddText(command->ToolTip, Vec4(1));
-    }
-
-    // Check if there's tooltip text not associated with commands.
-    if (!hasText && !mToolTipText.Empty())
-    {
-      hasText = true;
-      toolTip->AddText(mToolTipText, Vec4(1));
-    }
-
-    if (!hasText)
-    {
-      toolTip->Destroy();
-    }
-    else
-    {
-      toolTip->SetColorScheme(mToolTipColor);
-
-      ToolTipPlacement placement;
-      placement.SetScreenRect(GetScreenRect());
-      placement.SetPriority(IndicatorSide::Bottom, IndicatorSide::Right, IndicatorSide::Left, IndicatorSide::Top);
-      toolTip->SetArrowTipTranslation(placement);
-      // Temporary to fix jitter when the tool pops up
-      toolTip->UpdateTransform();
-      mToolTip = toolTip;
-    }
-  }
-}
-
 void ButtonBase::OnCommandStateChange(ObjectEvent* event)
 {
   MarkAsNeedsUpdate();
@@ -241,7 +192,7 @@ void ButtonBase::Activate()
 {
   mToolTip.SafeDestroy();
   mShowToolTip = false;
-
+  
   ObjectEvent e(this);
   GetDispatcher()->Dispatch(Events::ButtonPressed, &e);
 

--- a/Libraries/Widget/Button.hpp
+++ b/Libraries/Widget/Button.hpp
@@ -18,8 +18,6 @@ public:
 
   ButtonBase(Composite* parent, StringParam styleClass);
 
-  void SetToolTip(StringParam text);
-
   // ButtonBase Interface
   virtual void AddCommand(Command* command);
   virtual void OnCommandStateChange(ObjectEvent* event);
@@ -42,7 +40,6 @@ public:
   virtual void OnMouseExit(MouseEvent* event);
   void OnMouseDown(MouseEvent* event);
   void OnMouseUp(MouseEvent* event);
-  void OnHover(MouseEvent* event);
   void OnKeyDown(KeyboardEvent* event);
   void OnFocusGained(FocusEvent* event);
   void OnMouseClick(MouseEvent* event);
@@ -52,15 +49,6 @@ public:
   bool mMouseOver;
   bool mTabFocusStop;
   Array<Command*> mCommands;
-
-  /// When the button is pressed, we don't want the tooltip to be shown again
-  /// until the mouse has exited and re-entered the button. This helps protect
-  /// against the user pressing the button, Ui popping up below, and then
-  /// the tooltip popping up on top of the new Ui.
-  bool mShowToolTip;
-  String mToolTipText;
-  ToolTipColorScheme::Enum mToolTipColor;
-  HandleOf<Widget> mToolTip;
 };
 
 DeclareEnum2(TextButtonStyle, Classic, Modern);

--- a/Libraries/Widget/Composite.cpp
+++ b/Libraries/Widget/Composite.cpp
@@ -58,8 +58,10 @@ LightningDefineType(Composite, builder, type)
 Composite::Composite(Composite* parent, AttachType::Enum attachType) : Widget(parent, attachType)
 {
   mLayout = nullptr;
+  mShowToolTip = true;
   mMinSize = Vec2(10, 10);
   DebugValidate();
+  ConnectThisTo(this, Events::MouseHover, OnHoverToolTip);
 }
 
 Composite::~Composite()
@@ -419,6 +421,45 @@ Widget* Find(StringParam name, UiTraversal::Enum traversalType, size_t& index, W
   }
 
   return nullptr;
+}
+
+void Composite::SetToolTip(String text)
+{
+  mToolTipText = text;
+}
+
+void Composite::OnHoverToolTip(MouseEvent* e)
+{
+  if (mShowToolTip)
+  {
+    ToolTip* toolTip = new ToolTip(this);
+
+    bool hasText = false;
+
+    // Check if there's tooltip text not associated with commands.
+    if (!hasText && !mToolTipText.Empty())
+    {
+      hasText = true;
+      toolTip->AddText(mToolTipText, Vec4(1));
+    }
+
+    if (!hasText)
+    {
+      toolTip->Destroy();
+    }
+    else
+    {
+      toolTip->SetColorScheme(mToolTipColor);
+
+      ToolTipPlacement placement;
+      placement.SetScreenRect(GetScreenRect());
+      placement.SetPriority(IndicatorSide::Bottom, IndicatorSide::Right, IndicatorSide::Left, IndicatorSide::Top);
+      toolTip->SetArrowTipTranslation(placement);
+      // Temporary to fix jitter when the tool pops up
+      toolTip->UpdateTransform();
+      mToolTip = toolTip;
+    }
+  }
 }
 
 // Find any child widget by name

--- a/Libraries/Widget/Composite.hpp
+++ b/Libraries/Widget/Composite.hpp
@@ -97,6 +97,17 @@ private:
   static void InternalDetach(Composite* parent, Widget* child);
   static void InternalAttach(Composite* parent, Widget* child);
   bool mIsUpdatingTransform = false;
+
+  // Tooltip
+public:
+  void SetToolTip(String text);
+
+  bool mShowToolTip;
+  String mToolTipText;
+  ToolTipColorScheme::Enum mToolTipColor = ToolTipColorScheme::Default;
+  HandleOf<Widget> mToolTip;
+
+  void OnHoverToolTip(MouseEvent* e);
 };
 
 DeclareEnum3(UiTraversal, DirectDescendantsOnly, DepthFirst, BreadthFirst);

--- a/Libraries/Widget/Slider.cpp
+++ b/Libraries/Widget/Slider.cpp
@@ -353,6 +353,9 @@ void Slider::UpdateText()
 
 void Slider::OnMouseDown(MouseEvent* e)
 {
+  mToolTip.SafeDestroy();
+  mShowToolTip = false;
+  
   ObjectEvent eventToSend(this);
   GetDispatcher()->Dispatch(Events::SliderManipulationStarted, &eventToSend);
 
@@ -362,6 +365,9 @@ void Slider::OnMouseDown(MouseEvent* e)
 
 void Slider::OnRightClick(MouseEvent* e)
 {
+  mToolTip.SafeDestroy();
+  mShowToolTip = false;
+  
   StartEditText();
 }
 
@@ -478,6 +484,7 @@ void Slider::OnTextFocusLost(Event* e)
 
 void Slider::OnFocusLost(Event* e)
 {
+  mShowToolTip = true;
   if (mValueNudged)
     CommitValue(mValue);
 }

--- a/Libraries/Widget/ToolTip.hpp
+++ b/Libraries/Widget/ToolTip.hpp
@@ -29,8 +29,6 @@ struct ToolTipPlacement
   IndicatorSide::Type mPriority[4];
 };
 
-DeclareEnum6(ToolTipColorScheme, Default, Gray, Red, Yellow, Green, Orange);
-
 class ToolTip : public Composite
 {
 public:

--- a/Libraries/Widget/Widget.hpp
+++ b/Libraries/Widget/Widget.hpp
@@ -17,8 +17,8 @@ struct ColorTransform
   Vec4 ColorMultiply;
 };
 
+DeclareEnum6(ToolTipColorScheme, Default, Gray, Red, Yellow, Green, Orange);
 DeclareEnum2(FocusDirection, Forward, Backwards);
-
 DeclareEnum2(DisplayOrigin, TopLeft, Center);
 
 DeclareBitField4(DisplayFlags,

--- a/Libraries/Widget/WidgetStandard.cpp
+++ b/Libraries/Widget/WidgetStandard.cpp
@@ -3,7 +3,6 @@
 
 namespace Plasma
 {
-
 // Ranges
 LightningDefineRange(ContextMenuEntryChildren::range);
 

--- a/Libraries/Widget/WidgetStandard.hpp
+++ b/Libraries/Widget/WidgetStandard.hpp
@@ -60,6 +60,8 @@ public:
   static void Shutdown();
 };
 
+DeclareEnum6(ToolTipColorScheme, Default, Gray, Red, Yellow, Green, Orange);
+  
 } // namespace Plasma
 
 #include "WidgetMath.hpp"


### PR DESCRIPTION
Added settings for editor camera movement speed in viewport.
Moved Tooltip code from button to composite so all elements can have tooltips

Resolves #29 