### PR TITLE
fix shift + a crash 

### DIFF
--- a/Libraries/Editor/EditorCommands.cpp
+++ b/Libraries/Editor/EditorCommands.cpp
@@ -11,7 +11,7 @@ void AddToSelection(Space* space, MetaSelection* selection, BoundType* boundType
   {
     Cog* cog = &r.Front();
 
-    if (!cog->mFlags.IsSet(CogFlags::Protected))
+    if (!cog->mFlags.IsSet(CogFlags::Protected) && !cog->GetObjectViewHidden())
     {
       // Test to see if the component is present
       Component* component = cog->QueryComponentType(boundType);


### PR DESCRIPTION
pressing (shift + a) selected hidden objects that are not meant to be selected and causes a crash when the user tries to delete them.

This prevents them from selecting said objects.