### PR TITLE
Refactor uses of persistent data locations

### DIFF
--- a/Source/Core/Common/CommonStandard.cpp
+++ b/Source/Core/Common/CommonStandard.cpp
@@ -28,12 +28,12 @@ void CommonLibrary::Initialize()
          "  Application: %s\n"
          "      Working: %s\n"
          "    Documents: %s\n"
-         "        Local: %s\n"
+         "      AppData: %s\n"
          "    Temporary: %s\n",
          GetApplication().c_str(),
          GetWorkingDirectory().c_str(),
-         GetUserDocumentsDirectory().c_str(),
-         GetUserLocalDirectory().c_str(),
+         GetUserDocumentsApplicationDirectory().c_str(),
+         GetUserApplicationDirectory().c_str(),
          GetTemporaryDirectory().c_str());
 }
 

--- a/Source/Core/Common/Console.hpp
+++ b/Source/Core/Common/Console.hpp
@@ -20,7 +20,8 @@ enum Enum
   EngineFilter = 0x0010,      // Filter for Core Engine Operations
   ActiveFilter = 0x0020,      // Filter for debugging
   PerformanceFilter = 0x0040, // Filter for performance (Framerate, etc)
-  PhysicsFilter = 0x0080      // Filter for Physics
+  PhysicsFilter = 0x0080,     // Filter for Physics
+  ArchiveFilter = 0x0100,     // Filter for Archival operations
 };
 } // namespace Filter
 

--- a/Source/Core/Common/FileSystem.cpp
+++ b/Source/Core/Common/FileSystem.cpp
@@ -11,16 +11,24 @@
 namespace Plasma
 {
 
-String GetRemoteUserDocumentsApplicationDirectory(StringParam organization, StringParam applicationName)
+String GetUserApplicationDirectory(StringParam organization, StringParam applicationName)
 {
-  return FilePath::Combine(GetUserDocumentsDirectory(), BuildString(organization, applicationName));
+    return FilePath::Combine(GetUserLocalDirectory(), BuildString(organization, applicationName));
+}
+
+String GetUserApplicationDirectory()
+{
+    return GetUserApplicationDirectory(GetOrganization(), GetApplicationName());
+}
+
+String GetUserDocumentsApplicationDirectory(StringParam organization, StringParam applicationName)
+{
+    return FilePath::Combine(GetUserDocumentsDirectory(), BuildString(organization, applicationName));
 }
 
 String GetUserDocumentsApplicationDirectory()
 {
-  String directory = GetRemoteUserDocumentsApplicationDirectory(GetOrganization(), GetApplicationName());
-  CreateDirectoryAndParents(directory);
-  return directory;
+    return GetUserDocumentsApplicationDirectory(GetOrganization(), GetApplicationName());
 }
 
 String GetApplicationDirectory()

--- a/Source/Core/Common/FileSystem.hpp
+++ b/Source/Core/Common/FileSystem.hpp
@@ -127,17 +127,26 @@ PlasmaShared String GetWorkingDirectory();
 /// Set the working directory for this process.
 PlasmaShared void SetWorkingDirectory(StringParam path);
 
+
 /// Directory for application cache and config files.
 PlasmaShared String GetUserLocalDirectory();
 
-/// Directory for user modifiable configuration files.
+/// App Data Sub-Directory with a specific org.app identifier 
+PlasmaShared String GetUserApplicationDirectory(StringParam organization, StringParam applicationName);
+
+/// App Data Sub-Directory for the active application
+PlasmaShared String GetUserApplicationDirectory();
+
+
+/// Directory for user-facing files. Generally good as a starting directory for save dialogs.
 PlasmaShared String GetUserDocumentsDirectory();
 
-/// Directory for user modifiable files specific to a remote application.
-PlasmaShared String GetRemoteUserDocumentsApplicationDirectory(StringParam organization, StringParam applicationName);
+/// Documents Sub-Directory with a specific org.app identifier 
+PlasmaShared String GetUserDocumentsApplicationDirectory(StringParam organization, StringParam applicationName);
 
-/// Directory for user modifiable files specific to our application.
+/// Documents Sub-Directory for the active application 
 PlasmaShared String GetUserDocumentsApplicationDirectory();
+
 
 /// Directory to the application.
 PlasmaShared String GetApplicationDirectory();

--- a/Source/Core/Common/FileSystem.hpp
+++ b/Source/Core/Common/FileSystem.hpp
@@ -35,6 +35,9 @@ PlasmaShared void AddVirtualFileSystemEntry(StringParam absolutePath, DataBlock*
 /// Common/Platform library shuts down.
 PlasmaShared bool PersistFiles();
 
+/// For Editor: open platform's file/folder browser to path
+PlasmaShared bool BrowseDirectory(StringParam path);
+
 /// Copies a file. Will spin lock if fails up to a max number of iterations.
 /// (Calls CopyFileInternal) This operation will overwrite the destination file
 /// if it exists.

--- a/Source/Core/Content/ContentSystem.cpp
+++ b/Source/Core/Content/ContentSystem.cpp
@@ -95,7 +95,7 @@ ContentSystem::ContentSystem()
   IgnoredExtensions.Insert("libview");
   IgnoredExtensions.Insert("__pycache__");
 
-  HistoryPath = FilePath::Combine(GetUserDocumentsApplicationDirectory(), "History");
+  HistoryPath = FilePath::Combine(GetUserApplicationDirectory(), "History");
 }
 
 ContentSystem::~ContentSystem()
@@ -211,7 +211,6 @@ HandleOf<ResourcePackage> ContentSystem::BuildLibrary(Status& status, ContentLib
   // is faster than building the content ourselves, if it exists).
   if (!DirectoryExists(outputPath))
   {
-    String versionedContentName = FilePath::GetFileName(ContentOutputPath);
     String prebuiltContent = FilePath::Combine(PrebuiltContentPath, library->Name);
     if (DirectoryExists(prebuiltContent))
     {

--- a/Source/Core/Engine/Configuration.cpp
+++ b/Source/Core/Engine/Configuration.cpp
@@ -68,7 +68,7 @@ LightningDefineType(ContentConfig, builder, type)
   PlasmaBindComponent();
   PlasmaBindDocumented();
   type->AddAttribute(ObjectAttributes::cCore);
-  LightningBindFieldGetter(ContentOutput);
+  LightningBindFieldProperty(ContentOutput);
   LightningBindMethodProperty(PickNewContentOutput);
   PlasmaTodo("Change this into a warning that pops up when bContentOutputDirty is true");
   LightningBindCustomGetter(ContentPathChangedAndRequiresRestart);
@@ -89,7 +89,9 @@ void ContentConfig::PickNewContentOutput()
     FileDialogConfig* config = FileDialogConfig::Create();
     config->CallbackObject = this;
     config->Title = "Select new Content Output directory";
-    config->Flags = FileDialogFlags::Folder;
+    config->AddFilter("Content Output Folder", "*.none");
+    config->Flags |= FileDialogFlags::Folder;
+    config->DefaultFileName = ContentOutput;
     config->StartingDirectory = ContentOutput;
 
     ConnectThisTo(this, config->EventName, OnNewContentOutputPathSelected);

--- a/Source/Core/Engine/Configuration.cpp
+++ b/Source/Core/Engine/Configuration.cpp
@@ -68,16 +68,43 @@ LightningDefineType(ContentConfig, builder, type)
   PlasmaBindComponent();
   PlasmaBindDocumented();
   type->AddAttribute(ObjectAttributes::cCore);
-  PlasmaTodo("Add folder-select dialog for Editor ContentOutput path");
-  LightningBindFieldProperty(ContentOutput);
+  LightningBindFieldGetter(ContentOutput);
+  LightningBindMethodProperty(PickNewContentOutput);
+  PlasmaTodo("Change this into a warning that pops up when bContentOutputDirty is true");
+  LightningBindCustomGetter(ContentPathChangedAndRequiresRestart);
 }
 
 void ContentConfig::Serialize(Serializer& stream)
 {
   SerializeNameDefault(ContentOutput, String());
-  SerializeNameDefault(ToolsDirectory, String());
   SerializeNameDefault(LibraryDirectories, LibraryDirectories);
   SerializeNameDefault(HistoryEnabled, true);
+}
+
+void ContentConfig::PickNewContentOutput()
+{
+    // see DirectProperty
+    PlasmaTodo("Generalize into a FilePath property with a property editor");
+
+    FileDialogConfig* config = FileDialogConfig::Create();
+    config->CallbackObject = this;
+    config->Title = "Select new Content Output directory";
+    config->Flags = FileDialogFlags::Folder;
+    config->StartingDirectory = ContentOutput;
+
+    ConnectThisTo(this, config->EventName, OnNewContentOutputPathSelected);
+    PL::gEngine->has(OsShell)->SaveFile(config);
+}
+
+void ContentConfig::OnNewContentOutputPathSelected(OsFileSelection* event)
+{
+    if (event->Success == true && 
+        event->Files.Size() > 0 && DirectoryExists(event->Files[0]))
+    {
+        ContentOutput = event->Files[0];
+        bContentOutputDirty = true;
+        SaveConfig();
+    }
 }
 
 LightningDefineType(UserConfig, builder, type)

--- a/Source/Core/Engine/Configuration.cpp
+++ b/Source/Core/Engine/Configuration.cpp
@@ -397,25 +397,29 @@ Cog* LoadConfig(ModifyConfigFn modifier, void* userData)
   String dataDirectory = FilePath::Combine(sourceDirectory, cDataDirectoryName);
   const String defaultConfigFile = String::Format("Default%sConfiguration.data", GetApplicationName().c_str());
 
+  // for temporary use with cLookInOldConfigDirectory
+  String oldConfigFile = FilePath::Combine(GetUserDocumentsApplicationDirectory(), GetConfigFileName());
+
   Cog* configCog = nullptr;
 
   // Locations to look for the config file.
   // Some of them are absolute, some are relative to the working directory.
   Array<String> searchConfigPaths;
 
-  if (!useDefault)
-  {
-    // In the working directory (for exported projects).
-    searchConfigPaths.PushBack(GetConfigFileName());
-    // The user config in the appdata directory.
-    searchConfigPaths.PushBack(configFile);
-    
-    if (cLookInOldConfigDirectory)
+    if (!useDefault)
     {
-        // The user config in the documents directory.
-        searchConfigPaths.PushBack(FilePath::Combine(GetUserDocumentsApplicationDirectory(), GetConfigFileName()));
+        // In the working directory (for exported projects).
+        searchConfigPaths.PushBack(GetConfigFileName());
+        // The user config in the appdata directory.
+        searchConfigPaths.PushBack(configFile);
+
+        if (cLookInOldConfigDirectory)
+        {
+            // The user config in the documents directory.
+            searchConfigPaths.PushBack(oldConfigFile);
+        }
     }
-  }
+
   // In the source's Data directory.
   searchConfigPaths.PushBack(FilePath::Combine(dataDirectory, defaultConfigFile));
 
@@ -433,6 +437,15 @@ Cog* LoadConfig(ModifyConfigFn modifier, void* userData)
       }
     }
   }
+   
+    if (cLookInOldConfigDirectory)
+    {
+        // Remove old config so people don't get confused
+        if (FileExists(oldConfigFile))
+        {
+            DeleteFile(oldConfigFile);
+        }
+    }
 
   if (configCog == nullptr)
   {

--- a/Source/Core/Engine/Configuration.hpp
+++ b/Source/Core/Engine/Configuration.hpp
@@ -94,11 +94,15 @@ public:
 
   /// Content output directory.
   String ContentOutput;
-  /// Content tools directory.
-  String ToolsDirectory;
+  void PickNewContentOutput();
+  void OnNewContentOutputPathSelected(OsFileSelection* event);
+  bool bContentOutputDirty = false;
+  bool ContentPathChangedAndRequiresRestart() { return bContentOutputDirty; }
+
   /// Directories to search for shared content
   /// libraries.
   Array<String> LibraryDirectories;
+
   /// History stores files instead of deleting them
   bool HistoryEnabled;
 };

--- a/Source/Core/Engine/LauncherConfiguration.cpp
+++ b/Source/Core/Engine/LauncherConfiguration.cpp
@@ -39,7 +39,7 @@ void LauncherConfig::Serialize(Serializer& stream)
 
   SerializeNameDefault(mDefaultProjectSaveLocation,
                        FilePath::Combine(GetUserDocumentsApplicationDirectory(), "Projects"));
-  SerializeNameDefault(mDownloadPath, FilePath::Combine(GetUserDocumentsApplicationDirectory(), "Downloads"));
+  SerializeNameDefault(mDownloadPath, FilePath::Combine(GetUserApplicationDirectory(), "Downloads"));
   SerializeNameDefault(mDisplayBuildOnProjects, false);
   SerializeNameDefault(mShowDevelopmentBuilds, true);
   SerializeRename(mShowDevelopmentBuilds, "ShowNightlies");
@@ -49,6 +49,8 @@ void LauncherConfig::Serialize(Serializer& stream)
   SerializeNameDefault(mAutoUpdateFrequencyInSeconds, mDefaultReloadFrequency);
   float everyTwelveHours = 60 * 60 * 12;
   SerializeNameDefault(mNewestLauncherUpdateCheckFrequency, everyTwelveHours);
+
+  CreateDirectoryAndParents(mDefaultProjectSaveLocation);
 }
 
 void LauncherConfig::ApplyCommandLineArguments()

--- a/Source/Core/Engine/ObjectStore.cpp
+++ b/Source/Core/Engine/ObjectStore.cpp
@@ -6,48 +6,74 @@ namespace Plasma
 
 LightningDefineType(ObjectStore, builder, type)
 {
-  type->HandleManager = LightningManagerId(PointerManager);
+	type->HandleManager = LightningManagerId(PointerManager);
 
-  PlasmaBindDocumented();
+	PlasmaBindDocumented();
 
-  LightningBindGetter(EntryCount);
+	LightningBindGetter(EntryCount);
 
-  LightningBindMethodAs(IsEntryStored, "IsStored")->AddAttribute(DeprecatedAttribute);
-  LightningBindMethod(IsEntryStored);
-  LightningBindMethod(GetEntryAt);
-  LightningBindMethod(Store);
-  LightningBindMethod(Restore);
-  LightningBindMethod(RestoreOrArchetype);
-  LightningBindMethod(Erase);
-  LightningBindMethod(ClearStore);
-  LightningBindMethod(GetDirectoryPath);
+	LightningBindMethodAs(IsEntryStored, "IsStored")->AddAttribute(DeprecatedAttribute);
+	LightningBindMethod(IsEntryStored);
+	LightningBindMethod(GetEntryAt);
+	LightningBindMethod(Store);
+	LightningBindMethod(Restore);
+	LightningBindMethod(RestoreOrArchetype);
+	LightningBindMethod(Erase);
+	LightningBindMethod(ClearStore);
 }
 
 void ObjectStore::SetStoreName(StringParam storeName)
 {
-  String storePath = FilePath::Combine(GetUserDocumentsApplicationDirectory(), "Store", storeName);
-  if (DirectoryExists(storePath))
-    PopulateEntries(storePath);
-
-  mStoreName = storeName;
-  mStorePath = String();
+	// switch over to a new path and populate based on the files there
+	mStoreName = storeName;
+	String storePath = BuildStorePath();
+	SetupDirectory(storePath);
 }
 
-void ObjectStore::SetupDirectory()
+void ObjectStore::MigrateStoreLocation(StringParam oldLocation)
 {
-  if (mStorePath.Empty())
-  {
-    // Build the paths and create the directory to contain stored objects.
+	String newLocation = BuildStorePath();
 
-    // In User documents create a folder call Plasma.
-    String storePath = FilePath::Combine(GetUserDocumentsApplicationDirectory(), "Store", mStoreName);
+	// do nothing if it is the same location
+	if (newLocation == oldLocation)
+	{
+		return;
+	}
 
-    CreateDirectoryAndParents(storePath);
+	//create the directory to contain stored objects.
+	if (DirectoryExists(newLocation) == false)
+	{
+		CreateDirectoryAndParents(newLocation);
+	}
 
-    // save the path
-    mStorePath = storePath;
-    PopulateEntries(storePath);
-  }
+	// move the files
+	if (DirectoryExists(oldLocation))
+	{
+		MoveFolderContents(newLocation, oldLocation);
+		DeleteDirectory(oldLocation);
+		PersistFiles();
+	}
+	
+	// populate entries from the new directory
+	SetupDirectory(newLocation);
+}
+
+void ObjectStore::SetupDirectory(StringParam storePath)
+{
+	if (DirectoryExists(storePath) == false)
+	{
+		//create the directory to contain stored objects.
+		CreateDirectoryAndParents(storePath);
+	}
+
+	if (DirectoryExists(storePath))
+	{
+		PopulateEntries(storePath);
+	}
+	else
+	{
+		Warn("Failed to create directory for ObjectStore: %s", storePath.c_str());
+	}
 }
 
 void ObjectStore::PopulateEntries(StringParam storePath)
@@ -57,36 +83,45 @@ void ObjectStore::PopulateEntries(StringParam storePath)
   FileRange filesInDirectory(storePath);
   for (; !filesInDirectory.Empty(); filesInDirectory.PopFront())
   {
-    String filename = filesInDirectory.Front();
-    String name = FilePath::GetFileNameWithoutExtension(filename);
-    mEntries.PushBack(name);
+	String filename = filesInDirectory.Front();
+	String name = FilePath::GetFileNameWithoutExtension(filename);
+	mEntries.PushBack(name);
   }
 }
 
-String ObjectStore::GetFile(StringParam name)
+String ObjectStore::BuildStorePath()
 {
-  SetupDirectory();
-  return FilePath::CombineWithExtension(mStorePath, name, ".data");
+	return FilePath::Combine(GetUserApplicationDirectory(), "Store");
+}
+
+String ObjectStore::BuildTrashPath()
+{
+	return FilePath::Combine(GetUserApplicationDirectory(), "StoreTrash");
+}
+
+String ObjectStore::GetFullFilePath(StringParam storePath, StringParam entryName)
+{
+	return FilePath::CombineWithExtension(storePath, entryName, ".data");
 }
 
 bool ObjectStore::IsEntryStored(StringParam name)
 {
   if (!mEntries.Empty())
   {
-    int count = mEntries.Size();
-    for (int i = 0; i < count; ++i)
-    {
-      if (mEntries[i] == name)
-        return true;
-    }
+	int count = mEntries.Size();
+	for (int i = 0; i < count; ++i)
+	{
+	  if (mEntries[i] == name)
+		return true;
+	}
 
-    return false;
+	return false;
   }
   else
   {
-    // Check to is if file exists.
-    String storeFile = GetFile(name);
-    return FileExists(storeFile);
+	// Check to is if file exists.
+	String storeFile = GetFullFilePath(BuildStorePath(), name);
+	return FileExists(storeFile);
   }
 }
 
@@ -98,18 +133,12 @@ uint ObjectStore::GetEntryCount()
 String ObjectStore::GetEntryAt(uint index)
 {
   if (mEntries.Empty())
-    return String();
+	return String();
 
   if (index >= mEntries.Size())
-    return String();
+	return String();
 
   return mEntries[index];
-}
-
-String ObjectStore::GetDirectoryPath()
-{
-  SetupDirectory();
-  return mStorePath;
 }
 
 // Store an object.
@@ -117,14 +146,14 @@ StoreResult::Enum ObjectStore::Store(StringParam name, Cog* object)
 {
   ReturnIf(object == nullptr, StoreResult::Failed, "Can not store null object.");
 
-  String storeFile = GetFile(name);
+  String storeFile = GetFullFilePath(BuildStorePath(), name);
 
   // Default is added
   StoreResult::Enum result = StoreResult::Added;
 
   // If the file already exists set the result to replaced.
   if (FileExists(storeFile))
-    result = StoreResult::Replaced;
+	result = StoreResult::Replaced;
 
   Status status;
   // Create a text serializer
@@ -137,18 +166,18 @@ StoreResult::Enum ObjectStore::Store(StringParam name, Cog* object)
 
   if (status)
   {
-    if (result == StoreResult::Added)
-      mEntries.PushBack(name);
+	if (result == StoreResult::Added)
+	  mEntries.PushBack(name);
 
-    saver.SetSerializationContext(&savingContext);
-    saver.SaveFullObject(object);
-    saver.Close();
-    PersistFiles();
+	saver.SetSerializationContext(&savingContext);
+	saver.SaveFullObject(object);
+	saver.Close();
+	PersistFiles();
   }
   else
   {
-    PlasmaPrintFilter(Filter::DefaultFilter, "Failed to store object %s", name.c_str());
-    return StoreResult::Failed;
+	PlasmaPrintFilter(Filter::DefaultFilter, "Failed to store object %s", name.c_str());
+	return StoreResult::Failed;
   }
 
   return result;
@@ -159,20 +188,20 @@ Cog* ObjectStore::Restore(StringParam name, Space* space)
 {
   if (space == nullptr)
   {
-    DoNotifyException("Invalid ObjectStore Restore",
-                      "The space passed in was null. Cannot restore an object "
-                      "to an invalid space.");
-    return nullptr;
+	DoNotifyException("Invalid ObjectStore Restore",
+					  "The space passed in was null. Cannot restore an object "
+					  "to an invalid space.");
+	return nullptr;
   }
 
-  String storeFile = GetFile(name);
+  String storeFile = GetFullFilePath(BuildStorePath(), name);
 
   // Test to see if a file exists and restore it from
   // file if it exists
   if (FileExists(storeFile))
   {
-    Cog* cog = space->CreateNamed(storeFile);
-    return cog;
+	Cog* cog = space->CreateNamed(storeFile);
+	return cog;
   }
 
   return nullptr;
@@ -184,12 +213,12 @@ Cog* ObjectStore::RestoreOrArchetype(StringParam name, Archetype* archetype, Spa
 
   if (cog == nullptr && space != nullptr)
   {
-    // Object was not present in store use archetype.
-    cog = space->Create(archetype);
-    if (cog == nullptr)
-    {
-      PlasmaPrintFilter(Filter::DefaultFilter, "Failed to restore object %s", name.c_str());
-    }
+	// Object was not present in store use archetype.
+	cog = space->Create(archetype);
+	if (cog == nullptr)
+	{
+	  PlasmaPrintFilter(Filter::DefaultFilter, "Failed to restore object %s", name.c_str());
+	}
   }
 
   return cog;
@@ -198,35 +227,43 @@ Cog* ObjectStore::RestoreOrArchetype(StringParam name, Archetype* archetype, Spa
 void ObjectStore::Erase(StringParam name)
 {
   // Get the name of the file to remove
-  String storeFile = GetFile(name);
+  String storeFile = GetFullFilePath(BuildStorePath(), name);
 
   // First check if it exists
   if (FileExists(storeFile))
   {
-    // Get the path to where we're moving the file to (in the trash directory)
-    String trashDirectory = FilePath::Combine(GetUserDocumentsApplicationDirectory(), "StoreTrash");
-    String fileDestination = FilePath::Combine(trashDirectory, BuildString(name, ".Data"));
+	// Get the path to where we're moving the file to (in the trash directory)
+	String trashDirectory = BuildTrashPath();
+	String fileDestination = GetFullFilePath(trashDirectory, name);
 
-    // Create the trash directory if it doesn't exist
-    CreateDirectoryAndParents(trashDirectory);
+	// Create the trash directory if it doesn't exist
+	CreateDirectoryAndParents(trashDirectory);
 
-    // Move the file
-    MoveFile(fileDestination, storeFile);
+	// Move the file
+	MoveFile(fileDestination, storeFile);
 
-    mEntries.EraseValue(name);
-    PersistFiles();
+	mEntries.EraseValue(name);
+	PersistFiles();
   }
 }
 
 void ObjectStore::ClearStore()
 {
-  mEntries.Clear();
+	mEntries.Clear();
 
-  SetupDirectory();
-  String trashDirectory = FilePath::Combine(GetUserDocumentsApplicationDirectory(), "StoreTrash");
+	String storeDirectory = BuildStorePath();
+	String trashDirectory = BuildTrashPath();
 
-  MoveFolderContents(trashDirectory, mStorePath);
-  PersistFiles();
+	if (DirectoryExists(storeDirectory))
+	{
+		// Create the trash directory if it doesn't exist
+		CreateDirectoryAndParents(trashDirectory);
+
+		MoveFolderContents(trashDirectory, BuildStorePath());
+		PersistFiles();
+	}
+
+	SetupDirectory(storeDirectory);
 }
 
 } // namespace Plasma

--- a/Source/Core/Engine/ObjectStore.hpp
+++ b/Source/Core/Engine/ObjectStore.hpp
@@ -12,9 +12,11 @@ class ObjectStore : public ExplicitSingleton<ObjectStore>
 public:
   LightningDeclareType(ObjectStore, TypeCopyMode::ReferenceType);
 
-  /// Set the object store name. This is to prevent
-  /// store name conflicts.
+  /// Set the object store name. This is so each project has a separate store file.
   void SetStoreName(StringParam storeName);
+
+  /// Set the object store directory. This is so the local user can configure where persistent data is stored on their machine
+  void MigrateStoreLocation(StringParam oldLocation);
 
   /// Is there an entry record for the object in the store?
   bool IsEntryStored(StringParam name);
@@ -40,22 +42,22 @@ public:
   /// Clear the store
   void ClearStore();
 
-  /// Returns the directory path to the object store
-  String GetDirectoryPath();
-
 private:
-  // Helper function for file names.
-  String GetFile(StringParam name);
-  void SetupDirectory();
+	// Helper function for file names.
+	String BuildStorePath();
+	String BuildTrashPath();
+	String GetFullFilePath(StringParam storePath, StringParam entryName);
 
-  /// Populate the internal array of file names in the ObjectStore, if the
-  /// proper ObjectStore directory exists.
-  void PopulateEntries(StringParam storePath);
+	/// Create the store directory
+	void SetupDirectory(StringParam storePath);
 
-  String mStoreName;
-  String mStorePath;
+	/// Populate the internal array of file names in the ObjectStore, if the
+	/// proper ObjectStore directory exists.
+	void PopulateEntries(StringParam storePath);
 
-  Array<String> mEntries;
+	String mStoreName;
+
+	Array<String> mEntries;
 };
 
 } // namespace Plasma

--- a/Source/Core/Gameplay/Importer.cpp
+++ b/Source/Core/Gameplay/Importer.cpp
@@ -36,7 +36,7 @@ ImporterResult::Type Importer::CheckForImport()
   buffer.Read(status, (byte*)node->Data, node->Size);
   String uniqueName(node);
 
-  mOutputDirectory = FilePath::Combine(GetUserLocalDirectory(), uniqueName);
+  mOutputDirectory = FilePath::Combine(GetUserApplicationDirectory(), uniqueName);
 
   String applicationPath = GetApplication();
   String applicationName = FilePath::GetFileName(applicationPath);

--- a/Source/Core/SelfExtractor/Main.cpp
+++ b/Source/Core/SelfExtractor/Main.cpp
@@ -41,7 +41,7 @@ void Extract(const Array<String>& arguments)
 
   // Build the path that we're going to extract to.
   String extractName = BuildString(applicationName, ToString(hash));
-  String extractDirectoryPath = FilePath::Combine(GetUserLocalDirectory(), "PlasmaSelfExtractor", extractName);
+  String extractDirectoryPath = FilePath::Combine(GetUserApplicationDirectory(), "PlasmaSelfExtractor", extractName);
 
   // Get the executable name (hard-coded for now, but we could technically read
   // this from our data section).
@@ -57,7 +57,7 @@ void Extract(const Array<String>& arguments)
   {
     // Check to see if we already have the executable extracted.
     // We're technically writing to a user specific hidden directory that should
-    // persist (GetUserLocalDirectory) which means that after extraction, all
+    // persist (GetUserApplicationDirectory) which means that after extraction, all
     // the files should remain forever unless the user explicitly deletes them.
     if (FileExists(extractExecutablePath))
     {

--- a/Source/Core/Support/Archive.cpp
+++ b/Source/Core/Support/Archive.cpp
@@ -117,6 +117,8 @@ void Archive::Clear()
 
 void Archive::ArchiveDirectory(Status& status, StringParam path, StringParam parentPath, FileFilter* filter)
 {
+    PlasmaPrintFilter(Filter::ArchiveFilter, "Archiving directory %s\n", path.c_str());
+
   FileRange files(path);
   for (; !files.Empty(); files.PopFront())
   {
@@ -138,6 +140,8 @@ void Archive::ArchiveDirectory(Status& status, StringParam path, StringParam par
     }
     else
     {
+        PlasmaPrintFilter(Filter::ArchiveFilter, "Archiving file %s\n", files.Front().c_str());
+
       AddFile(fullPath, relativePath);
     }
   }

--- a/Source/Editor/EditorCore/AppCommands.cpp
+++ b/Source/Editor/EditorCore/AppCommands.cpp
@@ -195,6 +195,28 @@ void CopyPrebuiltContent()
   Download(outputDirectory);
 }
 
+void BrowseApplicationDirectory(StringParam directoryPath)
+{
+    const bool bSuccess = BrowseDirectory(directoryPath);
+    if (bSuccess == false)
+    {
+        Warn(BuildString("Failed to open path ", directoryPath).c_str());
+    }
+}
+
+void BrowseApplicationDocumentsDirectory()
+{
+    BrowseApplicationDirectory(GetUserDocumentsApplicationDirectory());
+}
+void BrowseApplicationDataDirectory()
+{
+    BrowseApplicationDirectory(GetUserApplicationDirectory());
+}
+void BrowseTemporaryDirectory()
+{
+    BrowseApplicationDirectory(GetTemporaryDirectory());
+}
+
 void BindAppCommands(Cog* config, CommandManager* commands)
 {
   commands->AddCommand("About", BindCommandFunction(ShowAbout), true);
@@ -219,6 +241,10 @@ void BindAppCommands(Cog* config, CommandManager* commands)
   commands->AddCommand("Documentation", BindCommandFunction(OpenDocumentation), true);
 
   commands->AddCommand("CopyPrebuiltContent", BindCommandFunction(CopyPrebuiltContent));
+
+  commands->AddCommand("BrowseApplicationDocumentsDirectory", BindCommandFunction(BrowseApplicationDocumentsDirectory));
+  commands->AddCommand("BrowseApplicationDataDirectory", BindCommandFunction(BrowseApplicationDataDirectory));
+  commands->AddCommand("BrowseTemporaryDirectory", BindCommandFunction(BrowseTemporaryDirectory));
 }
 
 } // namespace Plasma

--- a/Source/Editor/EditorCore/ArchiveProjectCommands.cpp
+++ b/Source/Editor/EditorCore/ArchiveProjectCommands.cpp
@@ -10,11 +10,24 @@ void ArchiveProjectFile(Cog* projectCog, StringParam filePath)
   ProjectSettings* project = projectCog->has(ProjectSettings);
   String projectDirectory = project->ProjectFolder;
 
+  PlasmaPrintFilter(Filter::ArchiveFilter, "Archive operation starting (%s -> %s)...\n", project->ProjectName.c_str(), filePath.c_str());
+
+  FilterFileRegex sourceControlFilter ("", ".*(\\.git).*");
+
   Status status;
   Archive projectArchive(ArchiveMode::Compressing);
-  projectArchive.ArchiveDirectory(status, projectDirectory);
+  projectArchive.ArchiveDirectory(status, projectDirectory, "", &sourceControlFilter);
+
+  PlasmaPrintFilter(Filter::ArchiveFilter, "Writing zip file (%s)...\n", filePath.c_str());
+
   projectArchive.WriteZipFile(filePath);
+
+  PlasmaPrintFilter(Filter::ArchiveFilter, "Zip file written.\n");
+  PlasmaPrintFilter(Filter::ArchiveFilter, "Downloading file (%s)...\n", filePath.c_str());
+
   Download(filePath);
+
+  PlasmaPrintFilter(Filter::ArchiveFilter, "File downloaded.\n");
 }
 
 class ArchiveProjectJob : public Job

--- a/Source/Editor/EditorCore/ArchiveProjectCommands.cpp
+++ b/Source/Editor/EditorCore/ArchiveProjectCommands.cpp
@@ -4,7 +4,8 @@
 namespace Plasma
 {
 
-void ArchiveProjectFile(Cog* projectCog, StringParam filename)
+// compresses the entire ProjectFolder into an archive at filePath
+void ArchiveProjectFile(Cog* projectCog, StringParam filePath)
 {
   ProjectSettings* project = projectCog->has(ProjectSettings);
   String projectDirectory = project->ProjectFolder;
@@ -12,8 +13,8 @@ void ArchiveProjectFile(Cog* projectCog, StringParam filename)
   Status status;
   Archive projectArchive(ArchiveMode::Compressing);
   projectArchive.ArchiveDirectory(status, projectDirectory);
-  projectArchive.WriteZipFile(filename);
-  Download(filename);
+  projectArchive.WriteZipFile(filePath);
+  Download(filePath);
 }
 
 class ArchiveProjectJob : public Job
@@ -27,17 +28,16 @@ public:
     ZoneScoped;
     SendBlockingTaskStart("Archiving");
 
-    ProjectSettings* project = mProject->has(ProjectSettings);
-
     ArchiveProjectFile(mProject, mFileName);
 
     SendBlockingTaskFinish();
   }
 };
 
-void StartArchiveJob(StringParam filename)
+// queues up an ArchiveProjectJob
+void StartArchiveJob(StringParam filename, ProjectSettings* project)
 {
-  Cog* projectCog = PL::gEditor->mProject;
+  Cog* projectCog = project->mOwner;
   PL::gEditor->SaveAll(true);
 
   ArchiveProjectJob* job = new ArchiveProjectJob();
@@ -46,32 +46,25 @@ void StartArchiveJob(StringParam filename)
   PL::gJobs->AddJob(job);
 }
 
-void BackupProject(ProjectSettings* project)
+struct ArchiveProjectModal : public SafeId32EventObject
 {
-  String backupDirectory = FilePath::Combine(GetUserDocumentsApplicationDirectory(), "Backups");
-  CreateDirectoryAndParents(backupDirectory);
-  String timeStamp = GetTimeAndDateStamp();
-  String fileName = BuildString(project->ProjectName, timeStamp, ".zip");
-  String fullPath = FilePath::Combine(backupDirectory, fileName);
-  StartArchiveJob(fullPath);
-}
+  typedef ArchiveProjectModal LightningSelf;
 
-struct ArchiveProjectCallback : public SafeId32EventObject
-{
-  typedef ArchiveProjectCallback LightningSelf;
-
-  ArchiveProjectCallback()
+  ArchiveProjectModal(String title, ProjectSettings* project, String fileName, String directory)
   {
+    mProject = project;
+
     const String CallBackEvent = "ArchiveCallback";
-    ProjectSettings* project = PL::gEditor->mProject.has(ProjectSettings);
+    CreateDirectoryAndParents(directory);
 
     FileDialogConfig* config = FileDialogConfig::Create();
     config->EventName = CallBackEvent;
     config->CallbackObject = this;
-    config->Title = "Archive a project";
+    config->Title = title;
     config->AddFilter("Zip", "*.zip");
-    config->DefaultFileName = BuildString(project->ProjectName, ".zip");
+    config->DefaultFileName = BuildString(fileName, ".zip");
     config->mDefaultSaveExtension = "zip";
+    config->StartingDirectory = directory;
 
     ConnectThisTo(this, CallBackEvent, OnArchiveProjectFile);
     PL::gEngine->has(OsShell)->SaveFile(config);
@@ -80,14 +73,27 @@ struct ArchiveProjectCallback : public SafeId32EventObject
   void OnArchiveProjectFile(OsFileSelection* event)
   {
     if (event->Success)
-      StartArchiveJob(event->Files[0]);
+      StartArchiveJob(event->Files[0], mProject);
     delete this;
   }
+
+  ProjectSettings* mProject;
 };
 
 void ArchiveProject(ProjectSettings* project)
 {
-  new ArchiveProjectCallback();
+    new ArchiveProjectModal("Archive project", project, 
+        project->ProjectName, GetUserDocumentsDirectory());
+}
+
+void BackupProject(ProjectSettings* project)
+{
+    String backupDirectory = FilePath::Combine(GetUserDocumentsApplicationDirectory(), "Backups");
+    String timeStamp = GetTimeAndDateStamp();
+    String fileName = BuildString(project->ProjectName, timeStamp);
+
+    new ArchiveProjectModal("Backup project", project, 
+        fileName, backupDirectory);
 }
 
 void ExportGame(ProjectSettings* project)

--- a/Source/Editor/EditorCore/ColorScheme.cpp
+++ b/Source/Editor/EditorCore/ColorScheme.cpp
@@ -188,7 +188,7 @@ void ColorScheme::Save()
     return;
   }
 
-  String userSchemeDirectory = FilePath::Combine(GetUserDocumentsApplicationDirectory(), "ColorSchemes");
+  String userSchemeDirectory = FilePath::Combine(GetUserApplicationDirectory(), "ColorSchemes");
   if (mFilePath.Empty())
     mFilePath = userSchemeDirectory;
 
@@ -236,6 +236,7 @@ void ColorScheme::LoadSchemes()
   TextEditorConfig* textConfig = configCog->has(TextEditorConfig);
 
   String userColorSchemeDirectory = FilePath::Combine(GetUserDocumentsApplicationDirectory(), "ColorSchemes");
+  CreateDirectoryAndParents(userColorSchemeDirectory);
   Enumerate(userColorSchemeDirectory);
 
   // Default color schemes are loaded second to overwrite user schemes using the

--- a/Source/Editor/EditorCore/ContentLogic.cpp
+++ b/Source/Editor/EditorCore/ContentLogic.cpp
@@ -19,17 +19,23 @@ void LoadContentConfig()
   String sourceDirectory = mainConfig->SourceDirectory;
   ErrorIf(sourceDirectory.Empty(), "Expected a source directory");
 
-  String contentOutputDirectory = GetUserDocumentsApplicationDirectory();
+  String contentOutputDirectory = GetUserApplicationDirectory();
 
   if (contentConfig)
   {
       librarySearchPaths.InsertAt(0, contentConfig->LibraryDirectories.All());
+
+      PlasmaPrint("Config has ContentOutput directory: '%s'\n", contentConfig->ContentOutput.c_str());
 
       if (contentConfig->ContentOutput.Empty() == false)
       {
           PlasmaTodo("(Matt, 2021-8-29): validate new content output path? Depends on whether validation occurs before serialization");
           contentOutputDirectory = contentConfig->ContentOutput;
       }
+  }
+  else
+  {
+      Warn("No ContentConfig found on Config Cog");
   }
 
   librarySearchPaths.PushBack(FilePath::Combine(sourceDirectory, "Resources"));

--- a/Source/Editor/EditorCore/Editor.cpp
+++ b/Source/Editor/EditorCore/Editor.cpp
@@ -368,6 +368,11 @@ void Editor::LoadDefaultLevel()
     String lastEditedLevel = configCog->has(EditorConfig)->EditingLevel;
     Level* lastEdited = LevelManager::FindOrNull(lastEditedLevel);
 
+    if (lastEditedLevel.Empty() == false && lastEdited == nullptr)
+    {
+        Warn("Couldn't load last edited level: %s", lastEditedLevel.c_str());
+    }
+
     // Is this level from this project?
     if (lastEdited && lastEdited->mContentItem->mLibrary == mProjectLibrary)
       level = lastEdited;

--- a/Source/Editor/EditorCore/Editor.cpp
+++ b/Source/Editor/EditorCore/Editor.cpp
@@ -368,14 +368,22 @@ void Editor::LoadDefaultLevel()
     String lastEditedLevel = configCog->has(EditorConfig)->EditingLevel;
     Level* lastEdited = LevelManager::FindOrNull(lastEditedLevel);
 
-    if (lastEditedLevel.Empty() == false && lastEdited == nullptr)
+    if (lastEdited == nullptr)
     {
-        Warn("Couldn't load last edited level: %s", lastEditedLevel.c_str());
+        if (lastEditedLevel.Empty() == false)
+        {
+            Warn("Couldn't load last edited level: %s", lastEditedLevel.c_str());
+        }
     }
-
     // Is this level from this project?
-    if (lastEdited && lastEdited->mContentItem->mLibrary == mProjectLibrary)
-      level = lastEdited;
+    else if (lastEdited->mContentItem->mLibrary != mProjectLibrary)
+    {
+        Warn("Cannot open previous level [%s] - not from Project Library", lastEditedLevel.c_str());
+    }
+    else
+    {
+        level = lastEdited;
+    }
   }
 
   GameSession* gameSession = GetEditGameSession();

--- a/Source/Editor/EditorCore/EditorCommands.cpp
+++ b/Source/Editor/EditorCore/EditorCommands.cpp
@@ -991,6 +991,10 @@ void ExportHeightMapToObj(Editor* editor, Space* space)
     {
         new ExportHeightMapModal(heightMap);
     }
+    else
+    {
+        Warn("No HeightMap on selected object %s", primary->GetName().c_str());
+    }
 }
 
 void Mode2D(Editor* editor)

--- a/Source/Editor/EditorCore/EditorMain.cpp
+++ b/Source/Editor/EditorCore/EditorMain.cpp
@@ -35,6 +35,8 @@ bool EditorMain::LoadPackage(Cog* projectCog, ContentLibrary* library, ResourceP
 
   ResourceSystem* resourceSystem = PL::gResources;
 
+  ContentLibrary* originalProjectLibrary = mProjectLibrary;
+
   // Set the content library so Loading may try to create new content for
   // fixing old content elements.
   mProjectLibrary = library;
@@ -46,6 +48,10 @@ bool EditorMain::LoadPackage(Cog* projectCog, ContentLibrary* library, ResourceP
 
   DoEditorSideImporting(package, nullptr);
   PL::gEditor->SetExploded(false, true);
+
+  // restore original mProjectLibrary value
+  mProjectLibrary = originalProjectLibrary;
+
   return true;
 }
 

--- a/Source/Editor/EditorCore/EditorProject.cpp
+++ b/Source/Editor/EditorCore/EditorProject.cpp
@@ -71,6 +71,7 @@ void LoadProject(Editor* editor, Cog* projectCog, StringParam path, StringParam 
   
   /// Store the library on the project
   project->ProjectContentLibrary = projectLibrary;
+  PL::gEditor->mProjectLibrary = projectLibrary;
 
   Status status;
   PL::gContentSystem->BuildLibrary(status, projectLibrary, true);
@@ -91,7 +92,7 @@ void LoadProject(Editor* editor, Cog* projectCog, StringParam path, StringParam 
     Status s;
     PL::gContentSystem->BuildLibrary(s, library, true);
   }
-  
+
   // Always select the first tool
   if (editor->Tools)
     editor->Tools->SelectToolIndex(0);

--- a/Source/Editor/EditorCore/HotKeyEditor.cpp
+++ b/Source/Editor/EditorCore/HotKeyEditor.cpp
@@ -22,7 +22,6 @@ static const String cDescriptionColumn = "Description";
 // Orange
 static const Vec4 cPlasmaCommandColor(1, 0.647f, 0, 1);
 
-static const bool cNotUsingHotKeyResource = true;
 static const bool cHotKeysEditable = false;
 
 /// HotKeyBinding ref when a binding conflict has occurred
@@ -846,19 +845,6 @@ HotKeyEditor::HotKeyEditor(Composite* parent) :
     mCurrentSort(CommandCompare::None)
 {
   mHotKeys = HotKeyCommands::GetInstance();
-
-  if (!cNotUsingHotKeyResource)
-  {
-    String userHotKeyFile = FilePath::Combine(GetUserDocumentsApplicationDirectory(), "Default.HotKeyDataSet.data");
-
-    if (!FileExists(userHotKeyFile))
-    {
-      String coreHotKeyFile; // =
-                             // HotKeyManager::GetDefault()->mContentItem->GetFullPath();
-
-      CopyFileInternal(userHotKeyFile, coreHotKeyFile);
-    }
-  }
 
   ConnectThisTo(LightningManager::GetInstance(), Events::ScriptsCompiledPostPatch, OnScriptsCompiled);
 

--- a/Source/Editor/EditorCore/ResourceEditors.cpp
+++ b/Source/Editor/EditorCore/ResourceEditors.cpp
@@ -21,6 +21,7 @@ void EditLevel(Editor* editor, Resource* resource)
   // Update the last edited level in the user configuration
   Cog* configCog = PL::gEngine->GetConfigCog();
   HasOrAdd<EditorConfig>(configCog)->EditingLevel = level->ResourceIdName;
+  SaveConfig();
 
   Space* space = editor->CreateNewSpace(CreationFlags::Editing);
   space->has(TimeSpace)->SetPaused(true);

--- a/Source/Editor/EditorCore/ResourceOperations.cpp
+++ b/Source/Editor/EditorCore/ResourceOperations.cpp
@@ -267,7 +267,7 @@ bool MoveResource(Resource* resource, ContentLibrary* targetContentLibrary, Reso
     String previousLocation = contentItem->mLibrary->SourcePath;
     HandleOf<Resource> resourceHandle = resource;
 
-    ReturnIf(!contentItem->mResourceIsContentItem, false, "Cannot move resource" + resource->Name + ".The resource is either corrupted or a resource that is unable to move.");
+    ReturnIf(!contentItem->mResourceIsContentItem, false, String("Cannot move resource" + resource->Name + ".The resource is either corrupted or a resource that is unable to move.").c_str());
     ReturnIf(targetContentLibrary == nullptr, false, "Cannot move resource to a null library.");
     ReturnIf(targetContentLibrary->GetReadOnly(), false, "Cannot move resource to a library that is read only.");
 
@@ -644,7 +644,7 @@ String GetResourceFileName(ResourceManager* resourceManager, StringParam resourc
 
 String GetEditorTrash()
 {
-  return FilePath::Combine(GetUserDocumentsApplicationDirectory(), "Trash");
+  return FilePath::Combine(GetUserApplicationDirectory(), "Trash");
 }
 
 // Code paths for new resource:

--- a/Source/Editor/EditorCore/StressTest.cpp
+++ b/Source/Editor/EditorCore/StressTest.cpp
@@ -263,7 +263,7 @@ StressTest::StressTest()
 {
   Seed = 1234;
   Frames = 1000;
-  LogFile = FilePath::Combine(GetUserDocumentsApplicationDirectory(), "StressTestLog.txt");
+  LogFile = "";
   CreateObjects = true;
   DestroyObjects = true;
   SetProperties = true;
@@ -296,10 +296,14 @@ StressTest::StressTest()
 
 void StressTest::Serialize(Serializer& stream)
 {
-  MetaSerializeProperties(this, stream);
+    MetaSerializeProperties(this, stream);
 
-  if (LogFile.Empty())
-    LogFile = FilePath::Combine(GetUserDocumentsApplicationDirectory(), "StressTestLog.txt");
+    if (LogFile.Empty())
+    {
+        String stressTestLogDirectory = GetUserDocumentsApplicationDirectory();
+        CreateDirectoryAndParents(stressTestLogDirectory);
+        LogFile = FilePath::Combine(stressTestLogDirectory, "StressTestLog.txt");
+    }
 }
 
 // StressTestDialog

--- a/Source/Editor/Modules/ExportTool/Exporter.cpp
+++ b/Source/Editor/Modules/ExportTool/Exporter.cpp
@@ -345,7 +345,7 @@ ExportUI::ExportUI(Composite* parent) : Composite(parent)
   mExportPath = new TextBox(pathRow);
   mExportPath->SetEditable(true);
   mExportPath->SetText(
-      FilePath::Combine(GetUserDocumentsApplicationDirectory(), "Exports", projectSettings->GetProjectName()));
+      FilePath::Combine(GetUserDocumentsDirectory(), projectSettings->GetProjectName()));
   mExportPath->SetSizing(SizeAxis::X, SizePolicy::Flex, Pixels(200));
 
   TextButton* pathSelectButton = new TextButton(pathRow);

--- a/Source/Editor/Modules/ExportTool/WindowsExportTarget.cpp
+++ b/Source/Editor/Modules/ExportTool/WindowsExportTarget.cpp
@@ -36,8 +36,6 @@ void WindowsExportTarget::ExportApplication()
     String projectFile = FilePath::Combine(outputPath, projectFileName);
     SaveToDataFile(*project->GetOwner(), projectFile);
 
-    String contentOutput = PL::gContentSystem->ContentOutputPath;
-
     // archive all core resources
     Archive engineArchive(ArchiveMode::Compressing);
     ArchiveLibraryOutput(engineArchive, "FragmentCore");

--- a/Source/Launcher/PlasmaLauncher/VersionSelector.cpp
+++ b/Source/Launcher/PlasmaLauncher/VersionSelector.cpp
@@ -862,7 +862,7 @@ BackgroundTask* VersionSelector::DownloadPatchLauncherUpdate(StringParam url)
 
   String majorVersionIdStr = ToString(GetMajorVersion());
   String launcherFolderName =
-      FilePath::Combine(GetUserLocalDirectory(), BuildString("PlasmaLauncher_", majorVersionIdStr, ".0"));
+      FilePath::Combine(GetUserApplicationDirectory(), BuildString("PlasmaLauncher_", majorVersionIdStr, ".0"));
   DownloadLauncherPatchInstallerJob* job = new DownloadLauncherPatchInstallerJob(url, launcherFolderName);
   job->mName = "Download Patch Installer";
 

--- a/Source/Launcher/PlasmaLauncherShell/Main.cpp
+++ b/Source/Launcher/PlasmaLauncherShell/Main.cpp
@@ -23,7 +23,7 @@ Plasma::String GetLauncherDownloadedPath()
 {
   String majorVersionIdStr = ToString(GetMajorVersion());
   String launcherFolderName = BuildString("PlasmaLauncher_", majorVersionIdStr, ".0");
-  String searchLocation = FilePath::Combine(GetUserLocalDirectory(), launcherFolderName);
+  String searchLocation = FilePath::Combine(GetUserApplicationDirectory(), launcherFolderName);
 
   String foundPath;
   int bestId = -1;

--- a/Source/Lightning/LightningAdditions/Project/Lightning/FilePathClass.cpp
+++ b/Source/Lightning/LightningAdditions/Project/Lightning/FilePathClass.cpp
@@ -43,7 +43,7 @@ namespace Lightning
 
     LightningFullBindGetterSetter(builder, type, &FilePathClass::GetWorkingDirectory, LightningNoOverload, &FilePathClass::SetWorkingDirectory, LightningNoOverload, "WorkingDirectory")->Description = FilePathClass::WorkingDirectoryDocumentation();
     LightningFullBindGetterSetter(builder, type, &FilePathClass::GetTemporaryDirectory, LightningNoOverload, LightningNoSetter, LightningNoOverload, "TemporaryDirectory")->Description = FilePathClass::TemporaryDirectoryDocumentation();
-    LightningFullBindGetterSetter(builder, type, &FilePathClass::GetUserLocalDirectory, LightningNoOverload, LightningNoSetter, LightningNoOverload, "UserLocalDirectory")->Description = FilePathClass::UserLocalDirectoryDocumentation();
+    LightningFullBindGetterSetter(builder, type, &FilePathClass::GetUserApplicationDirectory, LightningNoOverload, LightningNoSetter, LightningNoOverload, "UserApplicationDirectory")->Description = FilePathClass::UserApplicationDirectoryDocumentation();
 
     LightningFullBindGetterSetter(builder, type, &FilePathClass::GetUserDocumentsDirectory, LightningNoOverload, LightningNoSetter, LightningNoOverload, "UserDocumentsDirectory")->Description = FilePathClass::UserDocumentsDirectoryDocumentation();
     LightningFullBindGetterSetter(builder, type, &FilePathClass::GetExecutableDirectory, LightningNoOverload, LightningNoSetter, LightningNoOverload, "ExecutableDirectory")->Description = FilePathClass::ExecutableDirectoryDocumentation();
@@ -278,7 +278,7 @@ namespace Lightning
   }
 
   //***************************************************************************
-  String FilePathClass::GetUserLocalDirectory()
+  String FilePathClass::GetUserApplicationDirectory()
   {
     return AddTrailingDirectorySeparator(Plasma::GetUserLocalDirectory());
   }

--- a/Source/Lightning/LightningAdditions/Project/Lightning/FilePathClass.hpp
+++ b/Source/Lightning/LightningAdditions/Project/Lightning/FilePathClass.hpp
@@ -152,7 +152,7 @@ namespace Lightning
     LightningDocument(UserLocalDirectory,
     "Application saved information should be placed here (read/write/create permissions should be allowed). "
     "This will always include a directory separator at the end of the result.\n");
-    static String GetUserLocalDirectory();
+    static String GetUserApplicationDirectory();
     
     LightningDocument(UserDocumentsDirectory,
     "User saved data that the user can backup or modify should be placed here (read/write/create permissions should be allowed). "

--- a/Source/Lightning/LightningCore/FilePathClass.cpp
+++ b/Source/Lightning/LightningCore/FilePathClass.cpp
@@ -164,12 +164,12 @@ LightningDefineType(FilePathClass, builder, type)
       ->Description = FilePathClass::TemporaryDirectoryDocumentation();
   LightningFullBindGetterSetter(builder,
                             type,
-                            &FilePathClass::GetUserLocalDirectory,
+                            &FilePathClass::GetUserApplicationDirectory,
                             LightningNoOverload,
                             LightningNoSetter,
                             LightningNoOverload,
-                            "UserLocalDirectory")
-      ->Description = FilePathClass::UserLocalDirectoryDocumentation();
+                            "UserApplicationDirectory")
+      ->Description = FilePathClass::UserApplicationDirectoryDocumentation();
 
   LightningFullBindGetterSetter(builder,
                             type,
@@ -415,7 +415,7 @@ String FilePathClass::GetTemporaryDirectory()
   return AddTrailingDirectorySeparator(Plasma::GetTemporaryDirectory());
 }
 
-String FilePathClass::GetUserLocalDirectory()
+String FilePathClass::GetUserApplicationDirectory()
 {
   return AddTrailingDirectorySeparator(Plasma::GetUserLocalDirectory());
 }

--- a/Source/Lightning/LightningCore/FilePathClass.hpp
+++ b/Source/Lightning/LightningCore/FilePathClass.hpp
@@ -198,12 +198,12 @@ public:
                 "the result.\n");
   static String GetTemporaryDirectory();
 
-  LightningDocument(UserLocalDirectory,
+  LightningDocument(UserApplicationDirectory,
                 "Application saved information should be placed here "
                 "(read/write/create permissions should be allowed). "
                 "This will always include a directory separator at the end of "
                 "the result.\n");
-  static String GetUserLocalDirectory();
+  static String GetUserApplicationDirectory();
 
   LightningDocument(UserDocumentsDirectory,
                 "User saved data that the user can backup or modify should be placed "

--- a/Source/Platform/Empty/VirtualFileAndFileSystem.cpp
+++ b/Source/Platform/Empty/VirtualFileAndFileSystem.cpp
@@ -383,6 +383,11 @@ String CanonicalizePath(StringParam directoryPath)
   return FilePath::Normalize(directoryPath);
 }
 
+bool BrowseDirectory(StringParam path)
+{
+    return false;
+}
+
 String GetWorkingDirectory()
 {
   return FileSystem::GetInstance()->mWorkingDirectory;

--- a/Source/Platform/Posix/FileSystem.cpp
+++ b/Source/Platform/Posix/FileSystem.cpp
@@ -276,6 +276,11 @@ String UniqueFileId(StringParam fullpath)
   return fullpath;
 }
 
+bool BrowseDirectory(StringParam path)
+{
+    return false;
+}
+
 String GetWorkingDirectory()
 {
   char temp[File::MaxPath + 1];

--- a/Source/Platform/SDL/Shell.cpp
+++ b/Source/Platform/SDL/Shell.cpp
@@ -360,7 +360,7 @@ void Shell::OpenFile(FileDialogInfo& config)
 #if !defined(PlasmaPlatformNoShellSaveFile)
 void Shell::SaveFile(FileDialogInfo& config)
 {
-  String downloads = FilePath::Combine(GetUserDocumentsApplicationDirectory(), "Downloads");
+  String downloads = FilePath::Combine(GetUserApplicationDirectory(), "Downloads");
   CreateDirectoryAndParents(downloads);
 
   String filePath = FilePath::Combine(downloads, config.DefaultFileName);

--- a/Source/Platform/STD/FileSystem.cpp
+++ b/Source/Platform/STD/FileSystem.cpp
@@ -36,6 +36,11 @@ bool PersistFiles()
   return false;
 }
 
+bool BrowseDirectory(StringParam path)
+{
+    return false;
+}
+
 String GetWorkingDirectory()
 {
   std::error_code error;

--- a/Source/Platform/Windows/FileSystem.cpp
+++ b/Source/Platform/Windows/FileSystem.cpp
@@ -25,6 +25,16 @@ bool PersistFiles()
   return false;
 }
 
+bool BrowseDirectory(StringParam path)
+{
+    Status status;
+    status.CallbackOnFailure = Status::AssertCallback;
+
+    Process process;
+    process.Start(status, BuildString("explorer.exe ", path).c_str(), false, false, false, true);
+    return process.IsRunning();
+}
+
 String GetWorkingDirectory()
 {
   char temp[MAX_PATH + 1];


### PR DESCRIPTION
Performed an audit of where things are saving on disk. 

Based on existing comments, it seems that AppData (aka UserLocal or now UserApplication Directory) should be used for app-generated files that aren't intended to be seen/edited by the user. Note that this includes the Config file, so there is some code to help migrate existing config files to AppData.

The Documents folder is where any user-facing files should be put (that aren't part of a project). Since I strongly dislike programs that spit out to the Documents directory without configurability, I reworked most things to use a FileDialog with a default starting location of Documents.

I added 3 commands so that editor users can open the AppData, Documents, and Temp directories directly in explorer if they want to quickly browse to those locations.

For the ObjectStore, I allowed it to be moved at runtime, so if we want to allow players to configure where their save data goes we can allow that. 

Additionally, I fixed a bug where mProjectLibrary was being set to the last-loaded library, causing the editor to ignore the last edited level from the saved config file.