### PR TITLE
fixes for linux

### DIFF
--- a/CMakeFiles/Toolchain/GNU.cmake
+++ b/CMakeFiles/Toolchain/GNU.cmake
@@ -1,1 +1,1 @@
-include(GCC.cmake)
+GCC.cmake


### PR DESCRIPTION
move GCC.cmake -> GNU.cmake , fix build instructions, add dependency list