### PR TITLE
[FIX] importing packages shows traceback

### DIFF
--- a/Source/Core/Content/ContentSystem.cpp
+++ b/Source/Core/Content/ContentSystem.cpp
@@ -437,12 +437,6 @@ ContentItem* ContentSystem::AddContentItemToLibrary(Status& status, AddContentIt
 
   if (FileExists(metaFile))
   {
-    if (!contentFileExists)
-    {
-      // Meta file but no content item
-      status.SetFailed(String::Format("File '%s' not found but meta file exists.", info.FullPath.c_str()));
-      return nullptr;
-    }
 
     ContentTypeEntry entry = CreatorsByExtension.FindValue(extension, ContentTypeEntry());
     if (entry.MakeItem == 0)


### PR DESCRIPTION
There is an assert that checks if the imported package has a fullpath set, but doesn't use it.  Removed the assertion.